### PR TITLE
Fix success/error messages to use "excolink" and "member" instead of "address book" and "person" respectively

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,8 +61,8 @@ optimized for use via a Command Line Interface (CLI)** while still having the be
 - If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 
 - The GUI can display 2 alternative list views: member list view and subcommittee list view.
-  Certain commands can be run only in member list view, or only in subcommittee list view.
-  The required list view, if any, will be stated in "Required view" under the command format.
+  Certain commands can be run only in member list view, or only in subcommittee list view. In such cases, the user can
+  use `list` to switch to the member list view and `list-sc` to switch to the subcommittee list view.
 
 - In the **member list view**, each member card shows their name, phone number, email, roles, and subcommittee. 
   - If a member **has a subcommittee assigned**, it will be displayed in **bold text**.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,14 +59,17 @@ optimized for use via a Command Line Interface (CLI)** while still having the be
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 - If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
-</div>
 
 - The GUI can display 2 alternative list views: member list view and subcommittee list view.
   Certain commands can be run only in member list view, or only in subcommittee list view.
   The required list view, if any, will be stated in "Required view" under the command format.
+
 - In the **member list view**, each member card shows their name, phone number, email, roles, and subcommittee. 
   - If a member **has a subcommittee assigned**, it will be displayed in **bold text**.
   - If a member **is not assigned to a subcommittee**, **“No Subcommittee”** will appear instead in **unbolded text**.
+
+</div>
+
 ---
 
 ### Viewing help : `help`
@@ -77,8 +80,6 @@ Shows a message explaining how to access the help page.
 
 Format: `help`
 
-Required view: any
-
 ---
 
 ### Adding a member: `add`
@@ -87,7 +88,7 @@ Adds a member to ExcoLink.
 
 Format: `add n/NAME p/PHONE e/EMAIL [sc/SUBCOMMITEE] [r/ROLE]...`
 
-- Unable to add member with the same name(case-insensitive) and same phone number.
+- Unable to add a member with the same name (case-insensitive) and same phone number as an existing member.
 - If currently in the subcommittee list view, running this command will switch to the member list view.
 
 Required view: any

--- a/src/main/java/seedu/excolink/logic/Messages.java
+++ b/src/main/java/seedu/excolink/logic/Messages.java
@@ -22,10 +22,10 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_SUBCOM_NAME = "The subcommittee provided does not exist";
     public static final String MESSAGE_WRONG_DISPLAY_ENTITY_FOR_PERSON_COMMAND =
-            "This command cannot be used in the current view. Please switch to the person list first.\n"
+            "This command cannot be used in the current view. Please switch to the member list first.\n"
             + "Command: list";
     public static final String MESSAGE_WRONG_DISPLAY_ENTITY_FOR_SUBCOM_COMMAND =
-            "This command cannot be used in the current view. Please switch to the subcom list first.\n"
+            "This command cannot be used in the current view. Please switch to the subcommittee list first.\n"
             + "Command: list-sc";
 
     /**

--- a/src/main/java/seedu/excolink/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/AddCommand.java
@@ -24,7 +24,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a member to ExcoLink. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -37,8 +37,8 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ROLE + "Team Lead";
 
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_SUCCESS = "New member added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This member already exists in ExcoLink";
 
     private final Person toEdit;
 

--- a/src/main/java/seedu/excolink/logic/commands/AssignRoleCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/AssignRoleCommand.java
@@ -23,7 +23,7 @@ public class AssignRoleCommand extends Command {
     public static final String COMMAND_WORD = "assign-role";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Assigns one or more roles to the member identified by the "
-            + "index number used in the displayed person list.\n"
+            + "index number used in the displayed member list.\n"
             + "Parameters: INDEX (must be a positive integer) r/ROLE...\n"
             + "Example: " + COMMAND_WORD + " 1 r/Treasurer"
             + "Example: " + COMMAND_WORD + " 1 r/Team Lead r/Treasurer";

--- a/src/main/java/seedu/excolink/logic/commands/AssignSubcomCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/AssignSubcomCommand.java
@@ -23,7 +23,7 @@ public class AssignSubcomCommand extends Command {
     public static final String COMMAND_WORD = "assign-sc";
     public static final String MESSAGE_SUCCESS = "Assigned %1$s to subcommittee: %2$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assign a subcommittee for a member "
-            + "by the index number used in the displayed person list. "
+            + "by the index number used in the displayed member list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer)"
             + PREFIX_SUBCOM + "SUBCOMMITTEE\n"

--- a/src/main/java/seedu/excolink/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/DeleteCommand.java
@@ -21,11 +21,11 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
+            + ": Deletes the member identified by the index number used in the displayed member list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Member: %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/excolink/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/EditCommand.java
@@ -37,8 +37,8 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the member identified "
+            + "by the index number used in the displayed member list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
@@ -50,9 +50,9 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Member: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This member already exists in ExcoLink.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/excolink/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/ListCommand.java
@@ -13,7 +13,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all members";
 
 
     @Override

--- a/src/main/java/seedu/excolink/logic/commands/ListSubcomMembersCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/ListSubcomMembersCommand.java
@@ -18,13 +18,13 @@ public class ListSubcomMembersCommand extends Command {
     public static final String COMMAND_WORD = "list-sc-members";
     public static final String COMMAND_WORD_ALIAS = "list-scm";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " Lists all persons who are members of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " Lists all members of "
             + "the specified Subcom (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: SUBCOM_NAME\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_SUBCOM + " Publicity\n"
             + "Alternative format example: " + COMMAND_WORD_ALIAS + " " + PREFIX_SUBCOM + " Publicity";;
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons in subcommittee: %s";
+    public static final String MESSAGE_SUCCESS = "Listed all members in subcommittee: %s";
 
     private final Subcom subcomToList;
 

--- a/src/main/java/seedu/excolink/logic/commands/ListSubcomsCommand.java
+++ b/src/main/java/seedu/excolink/logic/commands/ListSubcomsCommand.java
@@ -12,7 +12,7 @@ public class ListSubcomsCommand extends Command {
 
     public static final String COMMAND_WORD = "list-sc";
 
-    public static final String MESSAGE_SUCCESS = "Listed all subcoms";
+    public static final String MESSAGE_SUCCESS = "Listed all subcommittees";
 
 
     @Override


### PR DESCRIPTION
Fixes #347 